### PR TITLE
Add detail texture files for 11 remaining maps

### DIFF
--- a/Copy-To-Redist.ps1
+++ b/Copy-To-Redist.ps1
@@ -1,0 +1,90 @@
+#Requires -Version 7.2
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+Set-PSDebug -Trace 0
+
+function Set-ConsoleColor ($bc, $fc) {
+    $Host.UI.RawUI.BackgroundColor = $bc
+    $Host.UI.RawUI.ForegroundColor = $fc
+}
+Set-ConsoleColor 'DarkCyan' 'White'
+
+$host.UI.RawUI.WindowTitle = "Copy Detail Textures to Redist"
+
+Write-Host "==================================" -ForegroundColor Cyan
+Write-Host "Copy Detail Textures to Redist" -ForegroundColor Cyan
+Write-Host "==================================" -ForegroundColor Cyan
+Write-Host ""
+
+$detailedTexturesRoot = $PSScriptRoot
+$redistRoot = Join-Path (Split-Path $PSScriptRoot -Parent) 'redist'
+
+# Verify paths exist
+if (-not (Test-Path $redistRoot)) {
+    Write-Error "Redist directory not found: $redistRoot"
+    exit 1
+}
+
+# Copy maps folder (detail texture mapping files)
+$sourceMaps = Join-Path $detailedTexturesRoot 'maps'
+$destMaps = Join-Path $redistRoot 'maps'
+
+if (Test-Path $sourceMaps) {
+    Write-Host "Copying detail texture mapping files..." -ForegroundColor Yellow
+    # Clean existing detail files before copying
+    if (Test-Path $destMaps) {
+        Write-Host "  Cleaning existing detail mapping files..." -ForegroundColor Cyan
+        Get-ChildItem -Path $destMaps -Filter '*_detail.txt' | Remove-Item -Force
+    }
+        $detailFiles = Get-ChildItem -Path $sourceMaps -Filter '*_detail.txt'
+    foreach ($file in $detailFiles) {
+        Copy-Item -Path $file.FullName -Destination $destMaps -Force
+        Write-Host "  Copied: $($file.Name)" -ForegroundColor Green
+    }
+    
+    Write-Host "Copied $($detailFiles.Count) detail mapping files" -ForegroundColor Green
+} else {
+    Write-Warning "Maps directory not found: $sourceMaps"
+}
+
+Write-Host ""
+
+# Copy gfx folder (detail texture TGA files)
+$sourceGfx = Join-Path $detailedTexturesRoot 'gfx'
+$destGfx = Join-Path $redistRoot 'gfx'
+
+if (Test-Path $sourceGfx) {
+    Write-Host "Copying detail texture TGA files..." -ForegroundColor Yellow
+    
+    # Ensure destination gfx/detail directory exists
+    $destGfxDetail = Join-Path $destGfx 'detail'
+    if (-not (Test-Path $destGfxDetail)) {
+        New-Item -ItemType Directory -Path $destGfxDetail -Force | Out-Null
+        Write-Host "  Created directory: gfx\detail" -ForegroundColor Cyan
+    } else {
+        # Clean existing files before copying
+        Write-Host "  Cleaning existing detail textures..." -ForegroundColor Cyan
+        Get-ChildItem -Path $destGfxDetail -Filter '*.tga' | Remove-Item -Force
+    }
+    
+    # Copy all TGA files from gfx/detail
+    $sourceGfxDetail = Join-Path $sourceGfx 'detail'
+    if (Test-Path $sourceGfxDetail) {
+        $tgaFiles = Get-ChildItem -Path $sourceGfxDetail -Filter '*.tga'
+        foreach ($file in $tgaFiles) {
+            Copy-Item -Path $file.FullName -Destination $destGfxDetail -Force
+        }
+        Write-Host "  Copied $($tgaFiles.Count) TGA files to gfx\detail" -ForegroundColor Green
+    } else {
+        Write-Warning "Detail textures directory not found: $sourceGfxDetail"
+    }
+} else {
+    Write-Warning "GFX directory not found: $sourceGfx"
+}
+
+Write-Host ""
+Write-Host "==================================" -ForegroundColor Cyan
+Write-Host "Copy completed successfully!" -ForegroundColor Green
+Write-Host "==================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Detail textures are now available in redist for testing in-game."

--- a/maps/cold_base_detail.txt
+++ b/maps/cold_base_detail.txt
@@ -1,0 +1,39 @@
+// Detail txtures for cold_base
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+{blue               	detail/{BLUE                   	1.0			1.0
++0~tnnl_lgt4        	detail/+0~tnnl_lgt2            	1.0			1.0
+babtech_wall01a     	detail/dt_metal1               	1.0			1.0
+basetrim01          	detail/dt_metal1               	1.0			1.0
+basewall04b         	detail/basewall04b             	1.0			1.0
+c1a1c_w2            	detail/c1a1c_w2                	1.0			1.0
+c1a3floor02         	detail/c1a3floor02             	1.0			1.0
+c1a3wall01          	detail/c1a3wall01              	1.0			1.0
+c1a3wall05          	detail/c1a3wall05              	1.0			1.0
+c1a4_c1c            	detail/c1a4_c1c                	1.0			1.0
+c1a4tnnl1           	detail/C1A4TNNL1               	1.0			1.0
+c3a1_w5d            	detail/c3a1_w5d                	1.0			1.0
+c3a2a_w1            	detail/dt_metal1               	1.0			1.0
+c3a2a_w1j           	detail/dt_metal1               	1.0			1.0
+cir_snow01          	detail/snow2                   	1.0			1.0
+cir_wall07          	detail/cir_wall07              	1.0			1.0
+cir_wall10          	detail/cir_wall10              	1.0			1.0
+con1_wall01p        	detail/con1_wall01p            	1.0			1.0
+fifties_cmp3b       	detail/FIFTIES_CMP3B           	1.0			1.0
+generic012          	detail/generic012              	1.0			1.0
+generic64b          	detail/dt_metal1               	1.0			1.0
+out_wall4b          	detail/out_wall4b              	1.0			1.0
+silo2_c1            	detail/dt_metal1               	1.0			1.0
+silo2_gad1          	detail/silo2_gad1              	1.0			1.0
+silo2_wet1          	detail/silo2_wet1              	1.0			1.0
+silo2_wet3          	detail/silo2_wet3              	1.0			1.0
+silo2_wet4          	detail/silo2_wet4              	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+tnnl_brd1b          	detail/tnnl_brd1b              	1.0			1.0
+tnnl_swr1           	detail/tnnl_swr1               	1.0			1.0
+tnnl_swr2           	detail/tnnl_swr1               	1.0			1.0
+xcrate10b           	detail/xcrate10b               	1.0			1.0
+xcrate11b           	detail/xcrate11b               	1.0			1.0
+

--- a/maps/comet_detail.txt
+++ b/maps/comet_detail.txt
@@ -1,0 +1,28 @@
+// Detail txtures for comet
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+{grate2a            	detail/dt_metal1               	1.0			1.0
++0~light1           	detail/+0~light1               	1.0			1.0
++0~light4a          	detail/crystallized1           	1.0			1.0
+babtech_ceil01      	detail/babtech_ceil01          	1.0			1.0
+black               	detail/black                   	1.0			1.0
+c3a2_ceil           	detail/c3a2_ceil               	1.0			1.0
+cardbox1            	detail/cardbox1                	1.0			1.0
+cardbox4            	detail/cardbox4                	1.0			1.0
+cardboxbot1         	detail/cardboxbot1             	1.0			1.0
+cir_crate15         	detail/cir_crate15             	1.0			1.0
+cir_crate16         	detail/crate_01                	1.0			1.0
+cir_floor04         	detail/cir_floor04             	1.0			1.0
+cir_snow02          	detail/snow2                   	1.0			1.0
+cir_wood08          	detail/cir_wood08              	1.0			1.0
+fade2               	detail/fade2                   	1.0			1.0
+lab1_trim3          	detail/lab1_trim3              	1.0			1.0
+lab1_trim4          	detail/lab1_trim4              	1.0			1.0
+metal_bord05        	detail/METAL_BORD05            	1.0			1.0
+out_gravel          	detail/out_gravel              	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+subway_lights       	detail/SUBWAY_LIGHTS           	1.0			1.0
+trk_seat            	detail/trk_seat                	1.0			1.0
+

--- a/maps/datafloe_detail.txt
+++ b/maps/datafloe_detail.txt
@@ -1,0 +1,46 @@
+// Detail txtures for datafloe
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+-0c2a4_pan1         	detail/-0c2a4_pan1             	1.0			1.0
+{ladder1            	detail/{LADDER1                	1.0			1.0
+{rail1              	detail/dt_metal1               	1.0			1.0
++0~light4a          	detail/crystallized1           	1.0			1.0
++0lab1_w7           	detail/+0lab1_w7               	1.0			1.0
++0medkit            	detail/dt_metal1               	1.0			1.0
++0recharge          	detail/dt_metal1               	1.0			1.0
+~generic88          	detail/~generic88              	1.0			1.0
+babtech_bordl9      	detail/babtech_bordl9          	1.0			1.0
+basetrim01          	detail/dt_metal1               	1.0			1.0
+black               	detail/black                   	1.0			1.0
+c2a4x_brd2b         	detail/c2a4x_brd2b             	1.0			1.0
+c2a4x_h2e           	detail/c2a4x_h2e               	1.0			1.0
+c2a4x_h2e2          	detail/c2a4x_h2e2              	1.0			1.0
+c2a4x_pan3          	detail/c2a4x_pan3              	1.0			1.0
+cir_snow01          	detail/snow2                   	1.0			1.0
+cir_snow02          	detail/snow2                   	1.0			1.0
+cir_wall07          	detail/cir_wall07              	1.0			1.0
+cir_wall09          	detail/cir_wall09              	1.0			1.0
+crete2_flr03c       	detail/crete2_flr03c           	1.0			1.0
+crete3_flr04        	detail/crete3_flr04            	1.0			1.0
+duct_wall01         	detail/duct_wall01             	1.0			1.0
+elev2_flr           	detail/elev2_flr               	1.0			1.0
+generic012          	detail/generic012              	1.0			1.0
+generic015h         	detail/generic015h             	1.0			1.0
+lab1_stair2a        	detail/lab1_stair2a            	1.0			1.0
+lab1_stair2b        	detail/lab1_stair2b            	1.0			1.0
+lab1_trim3          	detail/lab1_trim3              	1.0			1.0
+lab1_w8flr1b        	detail/lab1_w8flr1b            	1.0			1.0
+lab3_brd5           	detail/lab3_brd5               	1.0			1.0
+medkitedge1         	detail/dt_metal1               	1.0			1.0
+rechargeedge1       	detail/dt_metal1               	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+stripes2            	detail/stripes2                	1.0			1.0
+table               	detail/table                   	1.0			1.0
+tnnl_c3d            	detail/tnnl_c3d                	1.0			1.0
+tnnl_flr12a         	detail/tnnl_flr12a             	1.0			1.0
+tnnl_flr2           	detail/tnnl_flr2               	1.0			1.0
+tnnl_flr4           	detail/tnnl_flr4               	1.0			1.0
+tnnl_lgtbrd2        	detail/tnnl_lgtbrd2            	1.0			1.0
+

--- a/maps/defroster_detail.txt
+++ b/maps/defroster_detail.txt
@@ -1,0 +1,22 @@
+// Detail txtures for defroster
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+{blue               	detail/{BLUE                   	1.0			1.0
++0~generic85        	detail/crystallized1           	1.0			1.0
+black               	detail/black                   	1.0			1.0
+c1a4_c1c            	detail/c1a4_c1c                	1.0			1.0
+c3a1_w5d            	detail/c3a1_w5d                	1.0			1.0
+cir_floor04         	detail/cir_floor04             	1.0			1.0
+cir_snow01          	detail/snow2                   	1.0			1.0
+cir_snow04          	detail/snow2                   	1.0			1.0
+cir_wall10          	detail/cir_wall10              	1.0			1.0
+cir_wood12          	detail/cir_wood12              	1.0			1.0
+crete2_flr02        	detail/crete2_flr01            	1.0			1.0
+generic009          	detail/generic009              	1.0			1.0
+generic012          	detail/generic012              	1.0			1.0
+generic039          	detail/dt_metal1               	1.0			1.0
+out_pave2           	detail/out_pave2               	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+

--- a/maps/glacialcore_detail.txt
+++ b/maps/glacialcore_detail.txt
@@ -1,0 +1,22 @@
+// Detail txtures for glacialcore
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+{ladder1            	detail/{LADDER1                	1.0			1.0
++0lab1_w7           	detail/+0lab1_w7               	1.0			1.0
++0medkit            	detail/dt_metal1               	1.0			1.0
++0recharge          	detail/dt_metal1               	1.0			1.0
+black               	detail/black                   	1.0			1.0
+c1a0_w4             	detail/C1A0_W4                 	1.0			1.0
+cir_snow01          	detail/snow2                   	1.0			1.0
+duct_break          	detail/duct_break              	1.0			1.0
+duct_flr02          	detail/duct_flr02              	1.0			1.0
+duct_vnt            	detail/duct_vnt2               	1.0			1.0
+lab1_stair2a        	detail/lab1_stair2a            	1.0			1.0
+lab3_brd4b          	detail/lab3_brd4b              	1.0			1.0
+medkitedge1         	detail/dt_metal1               	1.0			1.0
+rechargeedge1       	detail/dt_metal1               	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+stripes2            	detail/stripes2                	1.0			1.0
+

--- a/maps/glupshitto_detail.txt
+++ b/maps/glupshitto_detail.txt
@@ -1,0 +1,10 @@
+// Detail txtures for glupshitto
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+cir_snow02          	detail/snow2                   	1.0			1.0
+lab1_stair1b        	detail/lab1_stair1b            	1.0			1.0
+lab1_trim3          	detail/lab1_trim3              	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+

--- a/maps/latenightxmas_detail.txt
+++ b/maps/latenightxmas_detail.txt
@@ -1,0 +1,19 @@
+// Detail txtures for latenightxmas
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+!waterblue          	detail/!WATERBLUE              	1.0			1.0
+{ladder1            	detail/{LADDER1                	1.0			1.0
++0~light4a          	detail/crystallized1           	1.0			1.0
++0~light6a          	detail/+0~LIGHT6A              	1.0			1.0
+black               	detail/black                   	1.0			1.0
+c1a0_wx             	detail/C1A0_WX                 	1.0			1.0
+c2a4e_w1            	detail/c2a4e_w1                	1.0			1.0
+cardbox1            	detail/cardbox1                	1.0			1.0
+fade2               	detail/fade2                   	1.0			1.0
+freezer_bx9         	detail/freezer_bx9             	1.0			1.0
+out_gravel          	detail/out_gravel              	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+trrm_wood2          	detail/TRRM_WOOD2              	1.0			1.0
+

--- a/maps/quadfrost_detail.txt
+++ b/maps/quadfrost_detail.txt
@@ -1,0 +1,60 @@
+// Detail txtures for quadfrost
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+-0genpipe1          	detail/dt_metal1               	1.0			1.0
+-0silo2_p2b         	detail/-0silo2_p2b_2           	1.0			1.0
+{blue               	detail/{BLUE                   	1.0			1.0
++0~fifts_lght3      	detail/+0~fifts_lght3          	1.0			1.0
++0~light4a          	detail/crystallized1           	1.0			1.0
++0~light6a          	detail/+0~LIGHT6A              	1.0			1.0
++0lab1_comp10e      	detail/dt_metal1               	1.0			1.0
++0medkit            	detail/dt_metal1               	1.0			1.0
++0recharge          	detail/dt_metal1               	1.0			1.0
+ammo01              	detail/ammo01                  	1.0			1.0
+babtech_ceil01      	detail/babtech_ceil01          	1.0			1.0
+basetrim01          	detail/dt_metal1               	1.0			1.0
+black               	detail/black                   	1.0			1.0
+brdly_btile1        	detail/brdly_btile1            	1.0			1.0
+c1a1_flr1           	detail/c1a1_flr1               	1.0			1.0
+c1a1_flr2a          	detail/c1a1_flr2a              	1.0			1.0
+c1a3floor02         	detail/c1a3floor02             	1.0			1.0
+c1a4tnnl1           	detail/C1A4TNNL1               	1.0			1.0
+c2a2_dr             	detail/c2a2_sd                 	1.0			1.0
+c2a3_gar3           	detail/c2a3_gar3               	1.0			1.0
+c2a5_gun1           	detail/c2a5_gun1               	1.0			1.0
+c3a1_w2a            	detail/c3a1_w2a                	1.0			1.0
+c3a1_w3a            	detail/c3a1_w3a                	1.0			1.0
+c3a1_w5a            	detail/c3a1_w5a                	1.0			1.0
+cir_snow02          	detail/snow2                   	1.0			1.0
+cir_snow04          	detail/snow2                   	1.0			1.0
+cir_wall10          	detail/cir_wall10              	1.0			1.0
+crete1_wall01       	detail/crete1_wall01           	1.0			1.0
+crete2_flr03c       	detail/crete2_flr03c           	1.0			1.0
+crete3_ceil02a      	detail/crete3_ceil02a          	1.0			1.0
+crete3_flr04        	detail/crete3_flr04            	1.0			1.0
+crete4_stp01        	detail/crete4_stp01            	1.0			1.0
+duct_vnt2           	detail/dt_metal1               	1.0			1.0
+duct_wall02         	detail/dt_metal1               	1.0			1.0
+fifties_cmp3b       	detail/FIFTIES_CMP3B           	1.0			1.0
+generic012          	detail/generic012              	1.0			1.0
+generic015h         	detail/generic015h             	1.0			1.0
+generic031b         	detail/dt_metal1               	1.0			1.0
+lab1_trim3          	detail/lab1_trim3              	1.0			1.0
+medkitedge1         	detail/dt_metal1               	1.0			1.0
+out_pav3            	detail/out_pav3                	1.0			1.0
+out_pave2           	detail/out_pave2               	1.0			1.0
+out_snbag           	detail/out_snbag               	1.0			1.0
+out_snbagc          	detail/out_snbagc              	1.0			1.0
+out_wall2c          	detail/out_wall2c              	1.0			1.0
+pfab_vent2          	detail/pfab_vent2              	1.0			1.0
+rechargeedge1       	detail/dt_metal1               	1.0			1.0
+silo2_brd1a         	detail/dt_metal1               	1.0			1.0
+silo2_brd1b         	detail/dt_metal1               	1.0			1.0
+silo2_w2b           	detail/dt_metal1               	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+stripes2            	detail/stripes2                	1.0			1.0
+stripes5            	detail/stripes5                	1.0			1.0
+tnnl_flr1a          	detail/tnnl_flr1a              	1.0			1.0
+

--- a/maps/storm_detail.txt
+++ b/maps/storm_detail.txt
@@ -1,0 +1,30 @@
+// Detail txtures for storm
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+-0out_crt2a         	detail/-0out_crt2a             	1.0			1.0
+{rail1              	detail/dt_metal1               	1.0			1.0
+black               	detail/black                   	1.0			1.0
+c1a0_wx             	detail/C1A0_WX                 	1.0			1.0
+cir_crate03         	detail/cir_crate03             	1.0			1.0
+cir_crate04         	detail/cir_crate04             	1.0			1.0
+cir_crate15         	detail/cir_crate15             	1.0			1.0
+cir_crate16         	detail/crate_01                	1.0			1.0
+cir_crate21         	detail/cir_crate21             	1.0			1.0
+cir_dirt04          	detail/cir_dirt04              	1.0			1.0
+cir_floor04         	detail/cir_floor04             	1.0			1.0
+cir_rock11          	detail/stone3                  	1.0			1.0
+cir_rock15          	detail/stone3                  	1.0			1.0
+cir_snow01          	detail/snow2                   	1.0			1.0
+cir_snow02          	detail/snow2                   	1.0			1.0
+cir_snow04          	detail/snow2                   	1.0			1.0
+cir_wall07          	detail/cir_wall07              	1.0			1.0
+lab1_stair2b        	detail/lab1_stair2b            	1.0			1.0
+lab1_trim3          	detail/lab1_trim3              	1.0			1.0
+lab1_w8ceil1        	detail/lab1_w8ceil1            	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+stripes2            	detail/stripes2                	1.0			1.0
+stripes4            	detail/stripes4                	1.0			1.0
+table               	detail/table                   	1.0			1.0
+

--- a/maps/thechill_detail.txt
+++ b/maps/thechill_detail.txt
@@ -1,0 +1,30 @@
+// Detail txtures for thechill
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
+{blue               	detail/{BLUE                   	1.0			1.0
+babtech_ceil01      	detail/babtech_ceil01          	1.0			1.0
+basetrim01          	detail/dt_metal1               	1.0			1.0
+black               	detail/black                   	1.0			1.0
+c1a3floor02         	detail/c1a3floor02             	1.0			1.0
+c1a3wall03          	detail/dt_metal1               	1.0			1.0
+c1a4_c1c            	detail/c1a4_c1c                	1.0			1.0
+c1a4i_w1a           	detail/c1a4i_w1a               	1.0			1.0
+c2a1_w1             	detail/c2a4e_w1                	1.0			1.0
+c3a1_w3b            	detail/c3a1_w3b                	1.0			1.0
+c3a1_w5a            	detail/c3a1_w5a                	1.0			1.0
+c3a1_w5d            	detail/c3a1_w5d                	1.0			1.0
+c3a2_telepad        	detail/c3a2_telepad            	1.0			1.0
+cir_snow01          	detail/snow2                   	1.0			1.0
+cir_snow02          	detail/snow2                   	1.0			1.0
+cir_snow04          	detail/snow2                   	1.0			1.0
+cir_wall10          	detail/cir_wall10              	1.0			1.0
+crete2_flr01        	detail/crete2_flr01            	1.0			1.0
+crete4_stp01        	detail/crete4_stp01            	1.0			1.0
+lab1_trim3          	detail/lab1_trim3              	1.0			1.0
+lab1_trim4          	detail/lab1_trim4              	1.0			1.0
+out_wall2c          	detail/out_wall2c              	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+stripes5            	detail/stripes5                	1.0			1.0
+

--- a/maps/thetemple_detail.txt
+++ b/maps/thetemple_detail.txt
@@ -1,0 +1,24 @@
+// Detail txtures for thetemple
+// Detail texture project for Cold Ice Remastered
+// Created by GitHub Copilot, 2026
+
+// [texture name]	[detail texture name]		[hscale]	[vscale]
++0~light1           	detail/+0~light1               	1.0			1.0
++0~light4a          	detail/crystallized1           	1.0			1.0
+babtech_ceil01      	detail/babtech_ceil01          	1.0			1.0
+black               	detail/black                   	1.0			1.0
+c1a0_wx             	detail/C1A0_WX                 	1.0			1.0
+cir_crate15         	detail/cir_crate15             	1.0			1.0
+cir_crate16         	detail/crate_01                	1.0			1.0
+cir_crate21         	detail/cir_crate21             	1.0			1.0
+cir_floor04         	detail/cir_floor04             	1.0			1.0
+cir_rock11          	detail/stone3                  	1.0			1.0
+cir_snow01          	detail/snow2                   	1.0			1.0
+cir_snow02          	detail/snow2                   	1.0			1.0
+cir_stone01         	detail/cir_stone01             	1.0			1.0
+cir_wall07          	detail/cir_wall07              	1.0			1.0
+lab1_stair2b        	detail/lab1_stair2b            	1.0			1.0
+out_pav3            	detail/out_pav3                	1.0			1.0
+out_pave2           	detail/out_pave2               	1.0			1.0
+sky                 	detail/SKY                     	1.0			1.0
+


### PR DESCRIPTION
Added detail texture mappings for:
- cold_base (33 textures)
- comet (22 textures)
- datafloe (40 textures)
- defroster (16 textures)
- glacialcore (16 textures)
- glupshitto (4 textures)
- latenightxmas (13 textures)
- quadfrost (54 textures)
- storm (24 textures)
- thechill (24 textures)
- thetemple (18 textures)

All mappings verified against existing textures in maps and available detail TGA files to prevent game crashes.